### PR TITLE
Remplacer les annotations Lombok par du code Java standard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.rbaudu</groupId>
     <artifactId>angel-server-capture</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <name>angel-server-capture</name>
+    <n>angel-server-capture</n>
     <description>Serveur de capture, synchronisation et analyse de flux vidéo et audio</description>
     
     <properties>
@@ -67,18 +67,6 @@
             <version>${ffmpeg.version}</version>
         </dependency>
         
-        <!-- Lombok to reduce boilerplate code -->
-        <!--<dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>-->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.26</version>
-			<scope>provided</scope>
-		</dependency>
 		 <!-- Pour javax.annotation.PostConstruct -->
 		<dependency>
 			<groupId>javax.annotation</groupId>
@@ -139,13 +127,6 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-							<version>1.18.26</version>
-						</path>
-					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
         </plugins>

--- a/src/main/java/com/rbaudu/angel/event/AudioEvent.java
+++ b/src/main/java/com/rbaudu/angel/event/AudioEvent.java
@@ -4,12 +4,9 @@ import org.springframework.context.ApplicationEvent;
 
 import com.rbaudu.angel.model.AudioChunk;
 
-import lombok.Getter;
-
 /**
  * Événement déclenché lorsqu'un nouveau segment audio est capturé.
  */
-@Getter
 public class AudioEvent extends ApplicationEvent {
     
     private static final long serialVersionUID = 1L;
@@ -28,5 +25,14 @@ public class AudioEvent extends ApplicationEvent {
     public AudioEvent(Object source, AudioChunk audioChunk) {
         super(source);
         this.audioChunk = audioChunk;
+    }
+    
+    /**
+     * Récupère le segment audio associé à cet événement.
+     * 
+     * @return le segment audio
+     */
+    public AudioChunk getAudioChunk() {
+        return audioChunk;
     }
 }

--- a/src/main/java/com/rbaudu/angel/event/SynchronizedMediaEvent.java
+++ b/src/main/java/com/rbaudu/angel/event/SynchronizedMediaEvent.java
@@ -4,12 +4,9 @@ import org.springframework.context.ApplicationEvent;
 
 import com.rbaudu.angel.model.SynchronizedMedia;
 
-import lombok.Getter;
-
 /**
  * Événement déclenché lorsqu'un média synchronisé est créé.
  */
-@Getter
 public class SynchronizedMediaEvent extends ApplicationEvent {
     
     private static final long serialVersionUID = 1L;
@@ -28,5 +25,14 @@ public class SynchronizedMediaEvent extends ApplicationEvent {
     public SynchronizedMediaEvent(Object source, SynchronizedMedia synchronizedMedia) {
         super(source);
         this.synchronizedMedia = synchronizedMedia;
+    }
+    
+    /**
+     * Récupère le média synchronisé associé à cet événement.
+     * 
+     * @return le média synchronisé
+     */
+    public SynchronizedMedia getSynchronizedMedia() {
+        return synchronizedMedia;
     }
 }

--- a/src/main/java/com/rbaudu/angel/event/VideoEvent.java
+++ b/src/main/java/com/rbaudu/angel/event/VideoEvent.java
@@ -4,12 +4,9 @@ import org.springframework.context.ApplicationEvent;
 
 import com.rbaudu.angel.model.VideoFrame;
 
-import lombok.Getter;
-
 /**
  * Événement déclenché lorsqu'une nouvelle trame vidéo est capturée.
  */
-@Getter
 public class VideoEvent extends ApplicationEvent {
     
     private static final long serialVersionUID = 1L;
@@ -28,5 +25,14 @@ public class VideoEvent extends ApplicationEvent {
     public VideoEvent(Object source, VideoFrame videoFrame) {
         super(source);
         this.videoFrame = videoFrame;
+    }
+    
+    /**
+     * Récupère la trame vidéo associée à cet événement.
+     * 
+     * @return la trame vidéo
+     */
+    public VideoFrame getVideoFrame() {
+        return videoFrame;
     }
 }


### PR DESCRIPTION
Ce PR remplace toutes les annotations Lombok restantes par du code Java standard.

Les changements incluent:
1. Remplacement de l'annotation `@Getter` dans les classes d'événements par des méthodes getter explicites
2. Suppression de la dépendance Lombok du pom.xml
3. Suppression du processeur d'annotation Lombok dans le plugin maven-compiler-plugin

Ces modifications permettent de simplifier la configuration du projet et d'éliminer la dépendance à Lombok.