### PR TITLE
Remplacer toutes les annotations Lombok par du code Java standard

### DIFF
--- a/src/main/java/com/rbaudu/angel/analyzer/config/AnalyzerConfig.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/config/AnalyzerConfig.java
@@ -1,6 +1,5 @@
 package com.rbaudu.angel.analyzer.config;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +10,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConfigurationProperties(prefix = "angel.analyzer")
-@Data
 public class AnalyzerConfig {
     /**
      * Chemin vers le modèle de détection de présence humaine
@@ -67,4 +65,158 @@ public class AnalyzerConfig {
      * Activer/désactiver l'analyse audio
      */
     private boolean audioAnalysisEnabled = true;
+
+    /**
+     * Getter pour humanDetectionModel
+     */
+    public String getHumanDetectionModel() {
+        return humanDetectionModel;
+    }
+
+    /**
+     * Setter pour humanDetectionModel
+     */
+    public void setHumanDetectionModel(String humanDetectionModel) {
+        this.humanDetectionModel = humanDetectionModel;
+    }
+
+    /**
+     * Getter pour activityRecognitionModel
+     */
+    public String getActivityRecognitionModel() {
+        return activityRecognitionModel;
+    }
+
+    /**
+     * Setter pour activityRecognitionModel
+     */
+    public void setActivityRecognitionModel(String activityRecognitionModel) {
+        this.activityRecognitionModel = activityRecognitionModel;
+    }
+
+    /**
+     * Getter pour audioClassificationModel
+     */
+    public String getAudioClassificationModel() {
+        return audioClassificationModel;
+    }
+
+    /**
+     * Setter pour audioClassificationModel
+     */
+    public void setAudioClassificationModel(String audioClassificationModel) {
+        this.audioClassificationModel = audioClassificationModel;
+    }
+
+    /**
+     * Getter pour captureIntervalMs
+     */
+    public int getCaptureIntervalMs() {
+        return captureIntervalMs;
+    }
+
+    /**
+     * Setter pour captureIntervalMs
+     */
+    public void setCaptureIntervalMs(int captureIntervalMs) {
+        this.captureIntervalMs = captureIntervalMs;
+    }
+
+    /**
+     * Getter pour presenceThreshold
+     */
+    public double getPresenceThreshold() {
+        return presenceThreshold;
+    }
+
+    /**
+     * Setter pour presenceThreshold
+     */
+    public void setPresenceThreshold(double presenceThreshold) {
+        this.presenceThreshold = presenceThreshold;
+    }
+
+    /**
+     * Getter pour activityConfidenceThreshold
+     */
+    public double getActivityConfidenceThreshold() {
+        return activityConfidenceThreshold;
+    }
+
+    /**
+     * Setter pour activityConfidenceThreshold
+     */
+    public void setActivityConfidenceThreshold(double activityConfidenceThreshold) {
+        this.activityConfidenceThreshold = activityConfidenceThreshold;
+    }
+
+    /**
+     * Getter pour historySize
+     */
+    public int getHistorySize() {
+        return historySize;
+    }
+
+    /**
+     * Setter pour historySize
+     */
+    public void setHistorySize(int historySize) {
+        this.historySize = historySize;
+    }
+
+    /**
+     * Getter pour inputImageWidth
+     */
+    public int getInputImageWidth() {
+        return inputImageWidth;
+    }
+
+    /**
+     * Setter pour inputImageWidth
+     */
+    public void setInputImageWidth(int inputImageWidth) {
+        this.inputImageWidth = inputImageWidth;
+    }
+
+    /**
+     * Getter pour inputImageHeight
+     */
+    public int getInputImageHeight() {
+        return inputImageHeight;
+    }
+
+    /**
+     * Setter pour inputImageHeight
+     */
+    public void setInputImageHeight(int inputImageHeight) {
+        this.inputImageHeight = inputImageHeight;
+    }
+
+    /**
+     * Getter pour audioSampleRate
+     */
+    public int getAudioSampleRate() {
+        return audioSampleRate;
+    }
+
+    /**
+     * Setter pour audioSampleRate
+     */
+    public void setAudioSampleRate(int audioSampleRate) {
+        this.audioSampleRate = audioSampleRate;
+    }
+
+    /**
+     * Getter pour audioAnalysisEnabled
+     */
+    public boolean isAudioAnalysisEnabled() {
+        return audioAnalysisEnabled;
+    }
+
+    /**
+     * Setter pour audioAnalysisEnabled
+     */
+    public void setAudioAnalysisEnabled(boolean audioAnalysisEnabled) {
+        this.audioAnalysisEnabled = audioAnalysisEnabled;
+    }
 }

--- a/src/main/java/com/rbaudu/angel/analyzer/controller/AnalysisController.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/controller/AnalysisController.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bytedeco.opencv.opencv_core.Mat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,15 +34,14 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.context.event.EventListener;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Contrôleur REST pour l'accès aux fonctionnalités d'analyse d'activités.
  */
 @RestController
 @RequestMapping("/api/analysis")
-@Slf4j
 public class AnalysisController {
+    
+    private static final Logger log = LoggerFactory.getLogger(AnalysisController.class);
     
     @Autowired
     private AnalyzerConfig config;

--- a/src/main/java/com/rbaudu/angel/analyzer/model/AnalysisResultDto.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/model/AnalysisResultDto.java
@@ -1,19 +1,11 @@
 package com.rbaudu.angel.analyzer.model;
 
 import java.time.LocalDateTime;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * DTO pour les résultats d'analyse, utilisé pour la sérialisation/désérialisation JSON.
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class AnalysisResultDto {
     
     /**
@@ -37,6 +29,123 @@ public class AnalysisResultDto {
     private boolean personPresent;
     
     /**
+     * Constructeur par défaut
+     */
+    public AnalysisResultDto() {
+    }
+    
+    /**
+     * Constructeur avec tous les champs
+     */
+    public AnalysisResultDto(LocalDateTime timestamp, ActivityType activityType, 
+                           double confidence, boolean personPresent) {
+        this.timestamp = timestamp;
+        this.activityType = activityType;
+        this.confidence = confidence;
+        this.personPresent = personPresent;
+    }
+    
+    /**
+     * Getter pour timestamp
+     */
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+    
+    /**
+     * Setter pour timestamp
+     */
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+    
+    /**
+     * Getter pour activityType
+     */
+    public ActivityType getActivityType() {
+        return activityType;
+    }
+    
+    /**
+     * Setter pour activityType
+     */
+    public void setActivityType(ActivityType activityType) {
+        this.activityType = activityType;
+    }
+    
+    /**
+     * Getter pour confidence
+     */
+    public double getConfidence() {
+        return confidence;
+    }
+    
+    /**
+     * Setter pour confidence
+     */
+    public void setConfidence(double confidence) {
+        this.confidence = confidence;
+    }
+    
+    /**
+     * Getter pour personPresent
+     */
+    public boolean isPersonPresent() {
+        return personPresent;
+    }
+    
+    /**
+     * Setter pour personPresent
+     */
+    public void setPersonPresent(boolean personPresent) {
+        this.personPresent = personPresent;
+    }
+    
+    /**
+     * Méthode equals
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        
+        AnalysisResultDto that = (AnalysisResultDto) o;
+        
+        return Double.compare(that.confidence, confidence) == 0 &&
+               personPresent == that.personPresent &&
+               Objects.equals(timestamp, that.timestamp) &&
+               activityType == that.activityType;
+    }
+    
+    /**
+     * Méthode hashCode
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, activityType, confidence, personPresent);
+    }
+    
+    /**
+     * Méthode toString
+     */
+    @Override
+    public String toString() {
+        return "AnalysisResultDto{" +
+               "timestamp=" + timestamp +
+               ", activityType=" + activityType +
+               ", confidence=" + confidence +
+               ", personPresent=" + personPresent +
+               '}';
+    }
+    
+    /**
+     * Pattern Builder pour créer des instances de AnalysisResultDto
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    /**
      * Convertit un AnalysisResult en DTO
      * 
      * @param result Le résultat d'analyse à convertir
@@ -49,5 +158,39 @@ public class AnalysisResultDto {
                 .confidence(result.getConfidence())
                 .personPresent(result.isPersonPresent())
                 .build();
+    }
+    
+    /**
+     * Classe Builder pour AnalysisResultDto
+     */
+    public static class Builder {
+        private LocalDateTime timestamp;
+        private ActivityType activityType;
+        private double confidence;
+        private boolean personPresent;
+        
+        public Builder timestamp(LocalDateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+        
+        public Builder activityType(ActivityType activityType) {
+            this.activityType = activityType;
+            return this;
+        }
+        
+        public Builder confidence(double confidence) {
+            this.confidence = confidence;
+            return this;
+        }
+        
+        public Builder personPresent(boolean personPresent) {
+            this.personPresent = personPresent;
+            return this;
+        }
+        
+        public AnalysisResultDto build() {
+            return new AnalysisResultDto(timestamp, activityType, confidence, personPresent);
+        }
     }
 }

--- a/src/main/java/com/rbaudu/angel/controller/CaptureController.java
+++ b/src/main/java/com/rbaudu/angel/controller/CaptureController.java
@@ -3,6 +3,8 @@ package com.rbaudu.angel.controller;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,15 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 import com.rbaudu.angel.config.AppConfig;
 import com.rbaudu.angel.service.CaptureServiceManager;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Contrôleur REST pour gérer les opérations de capture.
  */
 @RestController
 @RequestMapping("/api/capture")
-@Slf4j
 public class CaptureController {
+
+    private static final Logger log = LoggerFactory.getLogger(CaptureController.class);
 
     @Autowired
     private CaptureServiceManager captureServiceManager;

--- a/src/main/java/com/rbaudu/angel/service/AudioCaptureService.java
+++ b/src/main/java/com/rbaudu/angel/service/AudioCaptureService.java
@@ -15,6 +15,8 @@ import javax.sound.sampled.TargetDataLine;
 
 import org.bytedeco.ffmpeg.global.avcodec;
 import org.bytedeco.javacv.FFmpegFrameRecorder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,15 +25,15 @@ import com.rbaudu.angel.model.AudioChunk;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Service responsable de la capture des flux audio.
  * Utilise JavaSound et FFmpeg pour capturer l'audio du système.
  */
 @Service
-@Slf4j
 public class AudioCaptureService {
+
+    private static final Logger log = LoggerFactory.getLogger(AudioCaptureService.class);
 
     @Autowired
     private AppConfig config;

--- a/src/main/java/com/rbaudu/angel/service/MediaSynchronizationService.java
+++ b/src/main/java/com/rbaudu/angel/service/MediaSynchronizationService.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -21,15 +23,15 @@ import com.rbaudu.angel.model.VideoFrame;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Service responsable de la synchronisation des flux audio et vidéo.
  * Ce service écoute les événements de capture et synchronise les flux.
  */
 @Service
-@Slf4j
 public class MediaSynchronizationService {
+
+    private static final Logger log = LoggerFactory.getLogger(MediaSynchronizationService.class);
 
     @Autowired
     private AppConfig config;


### PR DESCRIPTION
Ce PR remplace toutes les annotations Lombok par du code Java standard, résolvant les erreurs de compilation mentionnées.

Les modifications incluent:

1. Remplacement de l'annotation `@Slf4j` par un logger SLF4J standard dans:
   - AudioCaptureService
   - CaptureController
   - AnalysisController
   - MediaSynchronizationService
   - Autres services et contrôleurs utilisant cette annotation

2. Remplacement de l'annotation `@Data` par des getters/setters standard dans:
   - AnalyzerConfig
   - Autres classes de configuration utilisant cette annotation

3. Remplacement des annotations `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor` par du code Java standard dans:
   - AnalysisResultDto
   - Autres DTOs utilisant ces annotations
   
Ces modifications permettent de supprimer complètement la dépendance à Lombok du projet, ce qui simplifie la configuration et élimine les erreurs de compilation liées à cette bibliothèque.