### PR TITLE
Remplacer Lombok par Java standard et corriger erreurs de compatibilité

### DIFF
--- a/src/main/java/com/rbaudu/angel/analyzer/model/AnalysisResultDto.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/model/AnalysisResultDto.java
@@ -1,6 +1,8 @@
 package com.rbaudu.angel.analyzer.model;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Objects;
 
 /**
@@ -152,8 +154,13 @@ public class AnalysisResultDto {
      * @return Le DTO correspondant
      */
     public static AnalysisResultDto fromAnalysisResult(AnalysisResult result) {
+        // Conversion de Instant à LocalDateTime
+        LocalDateTime localDateTime = result.getTimestamp() != null 
+            ? LocalDateTime.ofInstant(result.getTimestamp(), ZoneId.systemDefault()) 
+            : null;
+        
         return AnalysisResultDto.builder()
-                .timestamp(result.getTimestamp())
+                .timestamp(localDateTime)
                 .activityType(result.getActivityType())
                 .confidence(result.getConfidence())
                 .personPresent(result.isPersonPresent())
@@ -171,6 +178,16 @@ public class AnalysisResultDto {
         
         public Builder timestamp(LocalDateTime timestamp) {
             this.timestamp = timestamp;
+            return this;
+        }
+        
+        /**
+         * Conversion d'Instant à LocalDateTime pour compatibilité
+         */
+        public Builder timestamp(Instant instant) {
+            if (instant != null) {
+                this.timestamp = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            }
             return this;
         }
         

--- a/src/main/java/com/rbaudu/angel/analyzer/service/AnalysisOrchestrator.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/service/AnalysisOrchestrator.java
@@ -85,7 +85,7 @@ public class AnalysisOrchestrator {
             
         } catch (Exception e) {
             logger.error("Erreur pendant l'analyse de la frame", e);
-            return AnalysisResult.unknownActivity();
+            return AnalysisResult.unknownActivity(0.0);
         }
     }
     

--- a/src/main/java/com/rbaudu/angel/analyzer/service/fusion/MultimodalFusion.java
+++ b/src/main/java/com/rbaudu/angel/analyzer/service/fusion/MultimodalFusion.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -55,7 +55,7 @@ public class MultimodalFusion {
         
         // Création du résultat final
         AnalysisResult result = AnalysisResult.builder()
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())  // Utilise Instant au lieu de LocalDateTime
                 .activityType(bestActivity)
                 .confidence(maxScore)
                 .personPresent(bestActivity != ActivityType.ABSENT)

--- a/src/main/java/com/rbaudu/angel/controller/WebController.java
+++ b/src/main/java/com/rbaudu/angel/controller/WebController.java
@@ -1,6 +1,8 @@
 package com.rbaudu.angel.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,14 +11,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import com.rbaudu.angel.config.AppConfig;
 import com.rbaudu.angel.service.CaptureServiceManager;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Contrôleur pour gérer les vues de l'interface utilisateur.
  */
 @Controller
-@Slf4j
 public class WebController {
+
+    private static final Logger log = LoggerFactory.getLogger(WebController.class);
 
     @Autowired
     private AppConfig config;


### PR DESCRIPTION
Ce PR remplace toutes les annotations Lombok par du code Java standard et corrige les erreurs de compatibilité de type qui en résultent.

Les modifications incluent:

1. Remplacement de l'annotation `@Slf4j` par un logger SLF4J standard dans:
   - AudioCaptureService
   - CaptureController 
   - AnalysisController
   - MediaSynchronizationService
   - WebController
   - AnalysisService
   - Autres classes utilisant cette annotation

2. Remplacement de l'annotation `@Data` par des getters/setters standard dans:
   - AnalyzerConfig
   - Autres classes de configuration

3. Remplacement des annotations `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor` par du code Java standard dans:
   - AnalysisResultDto
   - Autres DTOs
   
4. Correction des problèmes de compatibilité de type:
   - Correction de la méthode `unknownActivity()` pour accepter le paramètre de confiance requis
   - Conversion entre `Instant` et `LocalDateTime` dans les classes DTO
   - Standardisation sur `Instant` pour les horodatages
   - Correction de la conversion pour les données audio en Base64

Ces modifications permettent de supprimer complètement la dépendance à Lombok du projet, ce qui simplifie la configuration et élimine les erreurs de compilation liées à cette bibliothèque.

Note: Il peut rester d'autres erreurs liées à TensorFlow et aux bibliothèques OpenCV qu'il faudra traiter séparément.